### PR TITLE
Fix Jest array paths

### DIFF
--- a/cli/modules/integrations/debug.js
+++ b/cli/modules/integrations/debug.js
@@ -9,7 +9,11 @@ const { indent, makeJson } = require('../../utils/text')
 
 function printConfig (data) {
   console.log()
-  console.log(indent(makeJson(data)))
+  const text = data === true
+    ? 'This plugin does not generate any output'.red
+    : makeJson(data)
+
+  console.log(indent(text))
 }
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/docs/cli/paths.md
+++ b/docs/cli/paths.md
@@ -102,7 +102,7 @@ Folders:
 - Any `paths` **must** resolve from the `baseUrl`, so if you need to go up a level from `src`, something like this is fine: `../packages`
 - The format supports [multiple paths](https://www.typescriptlang.org/tsconfig#paths), though
      - the CLI will only write a single path
-     - Jest is the only library to utilise this
+     - Jest v25+ is the only library to utilise this
 
 Content:
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -53,7 +53,7 @@ module.exports = {
 
 ## Rollup
 
-If bundling using Rollup and @rollup/plugin-alias, you can [add the aliases](https://github.com/rollup/plugins/tree/master/packages/alias#usage) using the `plugins.alias` configuration option:
+If bundling using Rollup and [@rollup/plugin-alias](https://github.com/rollup/plugins/tree/master/packages/alias) you can [add the aliases](https://github.com/rollup/plugins/tree/master/packages/alias#usage) using the `plugins.alias` configuration option:
 
 ```js
 // rollup.config.js
@@ -70,10 +70,10 @@ module.exports = {
 }
 ```
 
-You can request rollup paths in `object` or  `array` (the default) format:
+You can request paths in `object` (the default) or  `array` format:
 
 ```js
-hq.get('rollup', { format: 'object' })
+hq.get('rollup', { format: 'array' })
 ```
 
 ## Jest
@@ -88,6 +88,12 @@ module.exports = {
   ...
   moduleNameMapper: hq.get('jest'),
 }
+```
+
+You can request paths in `string` (the default) or  `array` (Jest v25+) format:
+
+```js
+hq.get('rollup', { format: 'array' })
 ```
 
 ## Vue

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alias-hq",
-  "version": "5.1.5",
+  "version": "5.1.6",
   "description": "The end-to-end solution for configuring, refactoring, maintaining and using path aliases",
   "main": "src/index.js",
   "bin": "bin/alias-hq",
@@ -13,7 +13,7 @@
     "cli": "node cli",
     "setup": "node cli -- setup",
     "test": "jest --verbose",
-    "test:plugins": "jest --watch -f plugins.spec.js -t 'available plugins:'",
+    "test:plugins": "jest --watch -f plugins/core.spec.js -t 'core plugins:'",
     "test:coverage": "jest --coverage"
   },
   "repository": {

--- a/src/plugins/jest/index.js
+++ b/src/plugins/jest/index.js
@@ -1,7 +1,12 @@
 const { toObject, join } = require('../../utils')
 
+const defaults = {
+  format: 'string'
+}
+
 // @see https://jestjs.io/docs/en/configuration#modulenamemapper-objectstring-string--arraystring
-function callback (name, config) {
+function callback (name, config, options) {
+  options = { ...defaults, ...options }
   const { baseUrl, paths } = config
   name = name
     .replace(/\*/, '(.*)')
@@ -11,7 +16,7 @@ function callback (name, config) {
       .replace(/\*/, '$1')
     return join('<rootDir>', baseUrl, path)
   })
-  if (path.length === 1) {
+  if (options.format === 'string' || path.length === 1) {
     path = path[0]
   }
   return {

--- a/src/plugins/jest/tests.js
+++ b/src/plugins/jest/tests.js
@@ -1,5 +1,26 @@
 module.exports = [
   function () {
+    const label = 'string'
+    const options = {
+      format: 'string'
+    }
+    const expected = {
+      '^@/(.*)$': '<rootDir>/src/$1',
+      '^@packages/(.*)$': '<rootDir>/packages/$1',
+      '^@classes/(.*)$': '<rootDir>/src/classes/$1',
+      '^@app/(.*)$': '<rootDir>/src/app/$1',
+      '^@data/(.*)$': '<rootDir>/src/app/data/$1',
+      '^@services/(.*)$': '<rootDir>/src/app/services/$1',
+      '^@views/(.*)$': '<rootDir>/src/app/views/$1'
+    }
+    return { label, options, expected }
+  },
+
+  function () {
+    const label = 'array'
+    const options = {
+      format: 'array'
+    }
     const expected = {
       '^@/(.*)$': '<rootDir>/src/$1',
       '^@packages/(.*)$': '<rootDir>/packages/$1',
@@ -12,6 +33,6 @@ module.exports = [
       ],
       '^@views/(.*)$': '<rootDir>/src/app/views/$1'
     }
-    return { expected }
+    return { label, options, expected }
   },
 ]

--- a/src/plugins/rollup/index.js
+++ b/src/plugins/rollup/index.js
@@ -1,7 +1,12 @@
 const { toArray, toObject, resolve, join } = require('../../utils')
 
+const defaults = {
+  format: 'object'
+}
+
 // @see https://github.com/rollup/plugins/tree/master/packages/alias
 function callback (name, config, options) {
+  options = { ...defaults, ...options }
   const { rootUrl, baseUrl } = config
   name = name
     .replace(/\/\*$/, '')


### PR DESCRIPTION
Modify plugin formats:

- Jest now has string and array format options
- Jest now outputs strings by default
- Rollup now outputs objects by default
- Fix test:plugins script

Closes #24 