### PR TITLE
Fix jest plugin omitting `<rootDir>` for aliases involving parent directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.1] - 2022-12-07
+### Fixed
+- Fixed jest plugin omitting `<rootDir>` for aliases involving parent directories (#57) - closes #45
+
 ## [6.1.0] - 2022-12-06
 ### Changed
 - Add Babel support (#60) - closes #56

--- a/cli/services/config.js
+++ b/cli/services/config.js
@@ -72,10 +72,10 @@ function getAliases () {
       }
     })
     .sort(function (a, b) {
-      if (a.absPath === b.absPath) {
+      if (a.relPath === b.relPath) {
         return 0
       }
-      return a.absPath > b.absPath ? -1 : 1
+      return a.relPath > b.relPath ? -1 : 1
     })
 
   /**

--- a/demo/jsconfig.json
+++ b/demo/jsconfig.json
@@ -14,7 +14,8 @@
         "app/services/*",
         "../packages/services/*"
       ],
-      "@views/*": ["app/views/*"]
+      "@views/*": ["app/views/*"],
+      "@alias-hq/*": ["../../src/*"]
     }
   }
 }

--- a/demo/tsconfig.base.json
+++ b/demo/tsconfig.base.json
@@ -14,7 +14,8 @@
         "app/services/*",
         "../packages/services/*"
       ],
-      "@views/*": ["app/views/*"]
+      "@views/*": ["app/views/*"],
+      "@alias-hq/*": ["../../src/*"]
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alias-hq",
-  "version": "5.4.0",
+  "version": "6.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alias-hq",
-      "version": "5.4.0",
+      "version": "6.1.1",
       "license": "MIT",
       "dependencies": {
         "colors": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alias-hq",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "The end-to-end solution for configuring, refactoring, maintaining and using path aliases",
   "bin": "bin/alias-hq",
   "exports": {

--- a/src/plugins/babel/tests.js
+++ b/src/plugins/babel/tests.js
@@ -9,6 +9,7 @@ module.exports = [
       '@settings': 'app/settings.js',
       '^@services/(.*)': 'app/services/\\1',
       '^@views/(.*)': 'app/views/\\1',
+      '^@alias-hq/(.*)': '../../src/\\1',
     }
     return { expected }
   },

--- a/src/plugins/jest/index.js
+++ b/src/plugins/jest/index.js
@@ -10,7 +10,7 @@ function callback (name, paths, config, options) {
   name = name.replace('*', '(.*)')
   let path = paths.map(path => {
     path = path.replace('*', '$1')
-    return join('<rootDir>', base, path)
+    return `<rootDir>/${join(base, path)}`
   })
   if (options.format === 'string' || path.length === 1) {
     path = path[0]

--- a/src/plugins/jest/tests.js
+++ b/src/plugins/jest/tests.js
@@ -13,6 +13,7 @@ module.exports = [
       '^@services/(.*)$': '<rootDir>/src/app/services/$1',
       '^@views/(.*)$': '<rootDir>/src/app/views/$1',
       '^@settings$': '<rootDir>/src/app/settings.js',
+      '^@alias-hq/(.*)$': '<rootDir>/../src/$1',
     }
     return { label, options, expected }
   },
@@ -34,6 +35,7 @@ module.exports = [
       ],
       '^@views/(.*)$': '<rootDir>/src/app/views/$1',
       '^@settings$': '<rootDir>/src/app/settings.js',
+      '^@alias-hq/(.*)$': '<rootDir>/../src/$1',
     }
     return { label, options, expected }
   },

--- a/src/plugins/rollup/tests.js
+++ b/src/plugins/rollup/tests.js
@@ -9,6 +9,7 @@ const expected = {
   '@settings': abs('app/settings.js'),
   '@services': abs('app/services'),
   '@views': abs('app/views'),
+  '@alias-hq': abs('../../src'),
 }
 
 module.exports = [
@@ -63,6 +64,10 @@ module.exports = [
       {
         find: '@views',
         replacement: abs('app/views')
+      },
+      {
+        find: '@alias-hq',
+        replacement: abs('../../src')
       },
     ]
     return { label, options, expected }

--- a/src/plugins/webpack/tests.js
+++ b/src/plugins/webpack/tests.js
@@ -11,6 +11,7 @@ module.exports = [
       '@services': abs('app/services'),
       '@views': abs('app/views'),
       '@settings': abs('app/settings.js'),
+      '@alias-hq': abs('../../src'),
     }
     return { expected }
   },

--- a/tests/specs/cli/get-aliases.spec.js
+++ b/tests/specs/cli/get-aliases.spec.js
@@ -18,6 +18,7 @@ describe('cli alias configuration', function () {
       '@settings',
       '@services',
       '@views',
+      '@alias-hq',
     ]
     expect(names).toEqual(expected)
   })
@@ -64,6 +65,11 @@ describe('cli alias configuration', function () {
         name: '@packages',
         absPath: abs('../packages'),
         relPath: 'packages',
+      },
+      {
+        name: '@alias-hq',
+        absPath: abs('../../src'),
+        relPath: '../src',
       }
     ]
     expect(lookup).toEqual(expected)

--- a/tests/specs/plugins/custom.spec.js
+++ b/tests/specs/plugins/custom.spec.js
@@ -23,6 +23,7 @@ const expected = {
   settings: { path: 'app/settings.js' },
   services: { path: 'app/services' },
   views: { path: 'app/views' },
+  'alias-hq': { path: '../../src' },
 }
 
 // ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This is a follow-up on #45 including the fix proposed by @chrissantamaria and adding tests for it. For the tests, I added an `@alias-hq/*` => `../../src` alias to the demo project which resolves to the `src` directory of the `alias-hq` package. The core and all plugins work as expected with the new alias; only the `jest` plugin failed due to #45 before applying the fix.

EDIT: Needless to say, I checked that jest works with `<rootDir>/../` paths.

Closes #45