### PR TITLE
Use get-tsconfig for tsconfig parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.2.3] - 2023-09-12
+
+Fixed:
+
+- Added back support for Node.js-style resolution of the tsconfig `extends` field which had been accidentally dropped in v6.2.0 (#73) - closes #72
+
 ## [6.2.2] - 2023-08-14
 
 Fixed:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alias-hq",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alias-hq",
-      "version": "6.2.2",
+      "version": "6.2.3",
       "license": "MIT",
       "dependencies": {
         "colors": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "alias-hq",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alias-hq",
-      "version": "6.2.1",
+      "version": "6.2.2",
       "license": "MIT",
       "dependencies": {
         "colors": "^1.4.0",
+        "get-tsconfig": "^4.7.0",
         "glob": "^7.1.6",
         "inquirer": "^7.3.3",
         "jscodeshift": "^0.13.0",
@@ -5018,6 +5019,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.0.tgz",
+      "integrity": "sha512-pmjiZ7xtB8URYm74PlGJozDNyhvsVLUcpBa8DZBG3bWHwaHa9bPiRpiSfovw+fjhwONSCWKRyk+JQHEGZmMrzw==",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/get-value": {
       "version": "2.0.6",
       "license": "MIT",
@@ -8807,6 +8819,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/resolve-url": {
@@ -13729,6 +13749,14 @@
         "get-intrinsic": "^1.1.1"
       }
     },
+    "get-tsconfig": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.0.tgz",
+      "integrity": "sha512-pmjiZ7xtB8URYm74PlGJozDNyhvsVLUcpBa8DZBG3bWHwaHa9bPiRpiSfovw+fjhwONSCWKRyk+JQHEGZmMrzw==",
+      "requires": {
+        "resolve-pkg-maps": "^1.0.0"
+      }
+    },
     "get-value": {
       "version": "2.0.6"
     },
@@ -16129,6 +16157,11 @@
     "resolve-from": {
       "version": "4.0.0",
       "dev": true
+    },
+    "resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="
     },
     "resolve-url": {
       "version": "0.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alias-hq",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "The end-to-end solution for configuring, refactoring, maintaining and using path aliases",
   "bin": "bin/alias-hq",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "colors": "^1.4.0",
+    "get-tsconfig": "^4.7.0",
     "glob": "^7.1.6",
     "inquirer": "^7.3.3",
     "jscodeshift": "^0.13.0",

--- a/src/index.js
+++ b/src/index.js
@@ -148,7 +148,6 @@ function loadConfig (path) {
   config.rootUrl = Path.dirname(path)
   config.baseUrl = baseUrl
   config.paths = paths
-  return true
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -192,7 +191,8 @@ function load (value = undefined) {
       // config.rootUrl will be an absolute folder path if loaded from package.json
       const path = Path.resolve(config.rootUrl, file)
       if (Fs.existsSync(path)) {
-        found = loadConfig(path)
+        loadConfig(path)
+        found = true
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const Fs = require('fs')
 const Path = require('path')
 const JSON5 = require('json5')
+const { parseTsconfig } = require('get-tsconfig')
 const { resolve } = require('./utils')
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -142,31 +143,12 @@ function loadSettings () {
  * @param   {string}    path      The absolute path to the config file
  */
 function loadConfig (path) {
-  /**
-   * @type {TSConfig}
-   */
-  const json = loadJson(path)
-  if (json) {
-    const { compilerOptions } = json
-    if (compilerOptions) {
-      const { baseUrl, paths } = compilerOptions
-
-      // Note that paths in the extending file take priority over paths in the extended file
-      // https://stackoverflow.com/questions/53804566/how-to-get-compileroptions-from-tsconfig-json
-      if (paths) {
-        settings.configFile = path
-        config.rootUrl = Path.dirname(path)
-        config.baseUrl = baseUrl || ''
-        config.paths = paths
-        return true
-      }
-    }
-
-    // if no paths, check extends
-    if (json.extends) {
-      return loadConfig(resolve(Path.dirname(path), json.extends))
-    }
-  }
+  const { compilerOptions: { baseUrl = '', paths = {} } } = parseTsconfig(path)
+  settings.configFile = path
+  config.rootUrl = Path.dirname(path)
+  config.baseUrl = baseUrl
+  config.paths = paths
+  return true
 }
 
 // ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #72 by utilizing the [get-tsconfig](https://github.com/privatenumber/get-tsconfig) package to parse ts/jsconfig files.