### PR TITLE
Support Fallbacks for Webpack and Babel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.3.0] - 2024-10-29
+
+Added:
+
+- Add fallbacks support for Babel and Webpack (#80) - closes #79
+
 ## [6.2.3] - 2023-09-12
 
 Fixed:

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -64,6 +64,12 @@ module.exports = {
 }
 ```
 
+The `format` option controls support for [fallbacks](https://www.typescriptlang.org/docs/handbook/modules/reference.html#fallbacks). Instead of `string` (the default), you can set `array` (Webpack v5+) to enable it:
+
+```js
+hq.get('webpack', { format: 'array' })
+```
+
 ## Rollup
 
 #### Basic setup

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -166,6 +166,12 @@ module.exports = {
 }
 ```
 
+The `format` option controls support for [fallbacks](https://www.typescriptlang.org/docs/handbook/modules/reference.html#fallbacks). Instead of `string` (the default), you can set `array` (Module Resolver v4+) to enable it:
+
+```js
+hq.get('babel', { format: 'array' })
+```
+
 For more info, check the plugin's [docs](https://github.com/tleunen/babel-plugin-module-resolver/blob/master/DOCS.md).
 
 # Frameworks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alias-hq",
-  "version": "6.2.4",
+  "version": "6.3.0",
   "description": "The end-to-end solution for configuring, refactoring, maintaining and using path aliases",
   "bin": "bin/alias-hq",
   "exports": {

--- a/src/plugins/babel/index.js
+++ b/src/plugins/babel/index.js
@@ -1,11 +1,20 @@
 const { toObject } = require('../../utils')
 
+const defaults = {
+  format: 'string'
+}
+
 // https://github.com/tleunen/babel-plugin-module-resolver/blob/HEAD/DOCS.md#alias
-function callback (alias, paths) {
+function callback (alias, paths, config, options) {
   // for babel to use a regex, the alias must start with a ^
   const prefix = alias.includes('*') ? '^' : ''
   const name = prefix + alias.replace('*', '(.*)')
-  const path = paths[0].replace('*', '\\1')
+  let path = paths.map(path => {
+    return path.replace('*', '\\1')
+  })
+  if (options.format === 'string' || path.length === 1) {
+    path = path[0]
+  }
   return {
     name,
     path,
@@ -13,5 +22,6 @@ function callback (alias, paths) {
 }
 
 module.exports = function (config, options) {
+  options = { ...defaults, ...options }
   return toObject(callback, config, options)
 }

--- a/src/plugins/babel/tests.js
+++ b/src/plugins/babel/tests.js
@@ -1,5 +1,9 @@
 module.exports = [
   function () {
+    const label = 'string'
+    const options = {
+      format: 'string'
+    }
     const expected = {
       '^@/(.*)': '/\\1',
       '^@packages/(.*)': '../packages/\\1',
@@ -11,6 +15,28 @@ module.exports = [
       '^@views/(.*)': 'app/views/\\1',
       '^@alias-hq/(.*)': '../../src/\\1',
     }
-    return { expected }
+    return { label, options, expected }
+  },
+
+  function () {
+    const label = 'array'
+    const options = {
+      format: 'array'
+    }
+    const expected = {
+      '^@/(.*)': '/\\1',
+      '^@packages/(.*)': '../packages/\\1',
+      '^@classes/(.*)': 'classes/\\1',
+      '^@app/(.*)': 'app/\\1',
+      '^@data/(.*)': 'app/data/\\1',
+      '@settings': 'app/settings.js',
+      '^@services/(.*)': [
+        'app/services/\\1',
+        '../packages/services/\\1',
+      ],
+      '^@views/(.*)': 'app/views/\\1',
+      '^@alias-hq/(.*)': '../../src/\\1',
+    }
+    return { label, options, expected }
   },
 ]

--- a/src/plugins/webpack/index.js
+++ b/src/plugins/webpack/index.js
@@ -1,11 +1,20 @@
 const { toObject, resolve } = require('../../utils')
 
+const defaults = {
+  format: 'string'
+}
+
 // @see https://webpack.js.org/configuration/resolve/#resolvealias
-function callback (name, [path], config) {
+function callback (name, paths, config, options) {
   const { root, base } = config
   name = name.replace(/\/\*$/, '')
-  path = path.replace(/\*$/, '')
-  path = resolve(root, base, path)
+  let path = paths.map(path => {
+    path = path.replace(/\*$/, '')
+    return resolve(root, base, path)
+  })
+  if (options.format === 'string' || path.length === 1) {
+    path = path[0]
+  }
   return {
     name,
     path,
@@ -13,5 +22,6 @@ function callback (name, [path], config) {
 }
 
 module.exports = function (config, options) {
+  options = { ...defaults, ...options }
   return toObject(callback, config, options)
 }

--- a/src/plugins/webpack/tests.js
+++ b/src/plugins/webpack/tests.js
@@ -2,6 +2,10 @@ const { abs } = require('../../utils')
 
 module.exports = [
   function () {
+    const label = 'string'
+    const options = {
+      format: 'string',
+    }
     const expected = {
       '@': abs(''),
       '@packages': abs('../packages'),
@@ -13,6 +17,28 @@ module.exports = [
       '@settings': abs('app/settings.js'),
       '@alias-hq': abs('../../src'),
     }
-    return { expected }
+    return { label, options, expected }
+  },
+
+  function () {
+    const label = 'array'
+    const options = {
+      format: 'array',
+    }
+    const expected = {
+      '@': abs(''),
+      '@packages': abs('../packages'),
+      '@classes': abs('classes'),
+      '@app': abs('app'),
+      '@data': abs('app/data'),
+      '@services': [
+        abs('app/services'),
+        abs('../packages/services'),
+      ],
+      '@views': abs('app/views'),
+      '@settings': abs('app/settings.js'),
+      '@alias-hq': abs('../../src'),
+    }
+    return { label, options, expected }
   },
 ]


### PR DESCRIPTION
Correctly handle configs using [fallbacks](https://www.typescriptlang.org/docs/handbook/modules/reference.html#fallbacks) like

```json
"paths": {
    "Types/*": ["../shared/src/types/*", "./src/types/*"],
}
```

when the `format: 'array'` option is set in the `'webpack'` and `'babel'` plugins.

Closes #79.